### PR TITLE
Adding clearfix to f-item-group

### DIFF
--- a/src/fabricator/styles/partials/_item.scss
+++ b/src/fabricator/styles/partials/_item.scss
@@ -1,5 +1,6 @@
 /* item */
 .f-item-group {
+	@include clearfix;
 	padding-bottom: 0.5em;
 	margin-bottom: 1.5em;
 }


### PR DESCRIPTION
I ran into an issue where one of the structures was a floated group of items, and the Structures page got messed up because each structure itself wasn't cleared.