### PR TITLE
Remove "margin-bottom" class from 'Light' f-color-chip

### DIFF
--- a/src/toolkit/views/index.html
+++ b/src/toolkit/views/index.html
@@ -35,7 +35,7 @@
 			<div class="f-color-chip__color">rgb(30,30,30)</div>
 		</div>
 
-		<div class="f-color-chip f-color-chip--primary margin-bottom">
+		<div class="f-color-chip f-color-chip--primary">
 			<div class="f-color-chip__name">Light</div>
 			<div class="f-color-chip__color">rgb(242,242,242)</div>
 		</div>


### PR DESCRIPTION
I think the class was mistakenly attached to the chip but it bothered me and I've been playing around with fabricator quite a bit lately.